### PR TITLE
Closes #11: optional param to verify server's TLS certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ After installation the OpenTapioca pipeline can be used without any other pipeli
 ```python
 import spacy
 nlp = spacy.blank("en")
-nlp.add_pipe('opentapioca')
+nlp.add_pipe('opentapioca', config={"verify": False})
 doc = nlp("Christian Drosten works in Germany.")
 for span in doc.ents:
     print((span.text, span.kb_id_, span.label_, span._.description, span._.score))
@@ -38,6 +38,8 @@ for span in doc.ents:
 ('Christian Drosten', 'Q1079331', 'PERSON', 'German virologist and university teacher', 3.6533377082098895)
 ('Germany', 'Q183', 'LOC', 'sovereign state in Central Europe', 2.1099332471902863)
 ```
+
+Note the optional `verify` parameter of config defaults to `True`. If the URL is not secure this parameter must be `False` for the pipeline to work. For example, the default [URL](https://opentapioca.wordlift.io/) is not secure and requires this parameter to be `False`. See [https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings](https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings) for more details.
 
 The types and aliases are also available:
 ```python
@@ -95,7 +97,7 @@ Batched asynchronous requests to the OpenTapioca API via `nlp.pipe(List[str])`:
 ```python
 import spacy
 nlp = spacy.blank("en")
-nlp.add_pipe('opentapioca')
+nlp.add_pipe('opentapioca', config={"verify": False})
 docs = nlp.pipe(
     [
         "Christian Drosten works in Germany.",
@@ -120,7 +122,7 @@ If OpenTapioca is deployed locally, specify the URL of the new OpenTapioca API i
 ```python
 import spacy
 nlp = spacy.blank("en")
-nlp.add_pipe('opentapioca', config={"url": OpenTapiocaAPI})
+nlp.add_pipe('opentapioca', config={"url": OpenTapiocaAPI, "verify": False})
 doc = nlp("Christian Drosten works in Germany.")
 ```
 ## Vizualization
@@ -131,7 +133,7 @@ Use manual option in displaCy:
 ```python
 import spacy
 nlp = spacy.blank("en")
-nlp.add_pipe('opentapioca')
+nlp.add_pipe('opentapioca', config={"verify": False})
 doc = nlp("Christian Drosten works\n in Charité, Germany.")
 params = {"text": doc.text,
           "ents": [{"start": ent.start_char,

--- a/spacyopentapioca/entity_linker.py
+++ b/spacyopentapioca/entity_linker.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import logging
+import warnings
 
 import requests
 import spacy
@@ -7,17 +8,22 @@ from spacy import util
 from spacy.language import Language
 from spacy.tokens import Doc, Span
 
+logging.captureWarnings(True)
 log = logging.getLogger(__name__)
-
 
 @Language.factory('opentapioca',
                   default_config={"url": "https://opentapioca.wordlift.io/api/annotate"})
 class EntityLinker(object):
     """Sends raw data to the OpenTapioca API. Attaches entities to the document."""
 
-    def __init__(self, nlp, name, url):
+    def __init__(self, nlp, name, url, verify=True):
         """Passes url. Registers OpenTapioca extensions for Doc and Span."""
         self.url = url
+        # Fix Issue #11: optional param to verify server's TLS certificate
+        if not verify:
+            log.warning("Unverified HTTPS request made to host %s. Making unverified HTTPS requests is strongly discouraged.\n",
+                url)
+        self.verify = verify
         Doc.set_extension("annotations", default=None, force=True)
         Doc.set_extension("metadata", default=None, force=True)
         Span.set_extension("annotations", default=None, force=True)
@@ -92,7 +98,8 @@ class EntityLinker(object):
     def make_request(self, doc: Doc):
         return requests.post(url=self.url,
                              data={'query': doc.text},
-                             headers={'User-Agent': 'spaCyOpenTapioca'})
+                             headers={'User-Agent': 'spaCyOpenTapioca'},
+                             verify=self.verify)
 
     def __call__(self, doc):
         """Requests the OpenTapioca API. Attaches entities to spans and doc."""

--- a/tests/test_opentapioca.py
+++ b/tests/test_opentapioca.py
@@ -6,7 +6,7 @@ class TestOpenTapioca(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         nlp = spacy.blank("en")
-        nlp.add_pipe('opentapioca')
+        nlp.add_pipe('opentapioca', config={"verify": False})
         cls.doc = nlp("Christian Drosten works in Germany")
 
     def test_opentapioca_api(self):


### PR DESCRIPTION
Fixes #11 

## Description
This pull request addresses the SSLError by including an optional parameter to verify server's TLS certificate. Though the behavior is strongly discouraged, this restores the wrapper's usability. Several users have expressed interest in the issue being resolved [here](https://github.com/explosion/spaCy/issues/13679) on spaCy.

### Type of change
The PR fixes a usability issue involving the verification of a secure server.

## Notes
Possible changes can be added if user wants to ignore the log warning. Otherwise I think everything looks good.